### PR TITLE
fix for permissions error

### DIFF
--- a/playbooks/part3_ec2/site.yml
+++ b/playbooks/part3_ec2/site.yml
@@ -20,7 +20,7 @@
 
       - name: Add instance to local host group
         # local_action: add_host hostname={{ item.public_ip }} groupname=launched
-        local_action: lineinfile dest=hosts regexp="{{ item.public_dns_name }}" insertafter="[launched]" line="{{ item.public_dns_name }} ansible_ssh_private_key_file=~/.ssh/{{ keypair }}.pem"
+        local_action: lineinfile dest="./hosts" regexp="{{ item.public_dns_name }}" insertafter="[launched]" line="{{ item.public_dns_name }} ansible_ssh_private_key_file=~/.ssh/{{ keypair }}.pem"
         with_items: ec2.instances
         #"
 


### PR DESCRIPTION
not sure if this is an OSX specific thing or what, but this fixes

`
msg: Could not replace file: /tmp/tmpgZ_KDw to hosts: [Errno 13] Permission denied: '/.hosts.78824.1397353883.67'
`
